### PR TITLE
Use f:format.html for rendering description

### DIFF
--- a/Resources/Private/Templates/Manager/List.html
+++ b/Resources/Private/Templates/Manager/List.html
@@ -16,7 +16,7 @@
 					<div class="collection-wrapper">
 						<div class="collection-header">
 							<h3 class="collection-title">{collection.title}</h3>
-							<f:if condition="{collection.description}"><p><f:format.raw>{collection.description}</f:format.raw></p></f:if>
+							<f:if condition="{collection.description}"><p><f:format.html>{collection.description}</f:format.html></p></f:if>
 						</div>
 						<ul class="collection-content">
 							<f:for each="{collection.items}" as="record">


### PR DESCRIPTION
Instead of using plain f:format.raw we should use f:format.html on a RTE-enabled field. This allows things like "click to enlarge" and other things provided by the RTE-parsefunc.